### PR TITLE
Fix off-by-one error in QuickPairProvider state restoration

### DIFF
--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1186,6 +1186,7 @@
 				}
 				_start(matches) {
 					this.reset();
+					this.next();
 					for (const m of matches) this.next(undefined, m.result);
 				}
 			}


### PR DESCRIPTION
The `_start` method in `QuickPairProvider` was failing to correctly restore the internal state from match history because it was passing the first result to `next()` while the provider was still in an unprimed state (`pairIdx === 0`). This caused the first result to be ignored and all subsequent results to be shifted, leading to corrupted states, especially during complex Merge-Insertion sort transitions.

I have:
1. Created a reproduction script to confirm the state mismatch after restoration.
2. Fixed the issue by calling `this.next()` once before the replay loop in `QuickPairProvider._start`.
3. Verified the fix with the reproduction script.
4. Ensured no regressions in existing logic and performance benchmarks.

---
*PR created automatically by Jules for task [6206871545503920936](https://jules.google.com/task/6206871545503920936) started by @mahalisyarifuddin*