### PR TITLE
Add Hayate-Shiki algorithm to benchmark

### DIFF
--- a/ANALYSIS-id.md
+++ b/ANALYSIS-id.md
@@ -17,39 +17,40 @@ Tabel ini dipartisi berdasarkan status Pareto dan diurutkan berdasarkan Rata-rat
 
 | Algoritma | Rata-rata Pertarungan | Rata-rata Kendall Tau | Status Pareto |
 | :--- | :--- | :--- | :--- |
-| Intelligent Design | 0.00 | 0.0331 | Pareto-optimal |
-| Miracle Sort | 99.00 | 0.5165 | Pareto-optimal |
-| Thanos Sort | 190.00 | 0.5265 | Pareto-optimal |
-| Intro Sort | 445.40 | 0.8566 | Pareto-optimal |
-| Ford-Johnson | 525.70 | 0.8937 | Pareto-optimal |
-| Binary Insertion | 529.90 | 0.8953 | Pareto-optimal |
-| Merge Sort | 543.80 | 0.9049 | Pareto-optimal |
-| **Shellsort** | **719.50** | **0.9446** | **Titik Lutut Produksi** |
-| Comb Sort | 1201.00 | 0.9897 | Pareto-optimal |
+| Intelligent Design | 0.00 | 0.0324 | Pareto-optimal |
+| Miracle Sort | 99.00 | 0.5413 | Pareto-optimal |
+| Smooth Sort | 170.20 | 0.5445 | Pareto-optimal |
+| Intro Sort | 456.80 | 0.8465 | Pareto-optimal |
+| Ford-Johnson | 526.20 | 0.8879 | Pareto-optimal |
+| Merge Sort | 542.10 | 0.8985 | Pareto-optimal |
+| **Shellsort** | **743.30** | **0.9387** | **Titik Lutut Produksi** |
+| Comb Sort | 1230.70 | 0.9905 | Pareto-optimal |
 | Full Rank | 4950.00 | 1.0000 | Pareto-optimal |
-| Quantum Bogo | 1.40 | -0.0349 | Terdominasi |
-| Stalin Sort | 99.00 | 0.1055 | Terdominasi |
-| Smooth Sort | 147.00 | 0.4847 | Terdominasi |
-| Heap Sort | 147.20 | 0.4650 | Terdominasi |
-| Patience Sort | 243.70 | 0.4525 | Terdominasi |
-| Tournament Sort | 556.40 | 0.8895 | Terdominasi |
-| Tree Sort | 598.10 | 0.8354 | Terdominasi |
-| Quicksort | 647.20 | 0.8359 | Terdominasi |
-| Strand Sort | 705.50 | 0.8321 | Terdominasi |
-| Bitonic Sort | 1334.00 | 0.9477 | Terdominasi |
-| Insertion Sort | 2581.00 | 0.8063 | Terdominasi |
-| Cocktail Shaker | 4011.00 | 0.9802 | Terdominasi |
-| Odd-Even Sort | 4682.70 | 0.9896 | Terdominasi |
-| Bubble Sort | 4884.40 | 0.9709 | Terdominasi |
-| Gnome Sort | 4895.60 | 0.9660 | Terdominasi |
-| Selection Sort | 4950.00 | 0.9339 | Terdominasi |
-| Bogosort | 4950.00 | 0.9789 | Terdominasi |
-| Pancake Sort | 4950.00 | 0.9762 | Terdominasi |
-| Bozosort | 4950.00 | 0.5992 | Terdominasi |
-| Slowsort | 4950.00 | 0.4645 | Terdominasi |
-| Cycle Sort | 4950.00 | 0.3362 | Terdominasi |
-| Stooge Sort | 4950.00 | 0.3124 | Terdominasi |
-| BogoBogoSort | 4950.00 | 0.0487 | Terdominasi |
+| Quantum Bogo | 1.70 | 0.0230 | Terdominasi |
+| Stalin Sort | 99.00 | 0.0640 | Terdominasi |
+| Heap Sort | 164.30 | 0.4808 | Terdominasi |
+| Thanos Sort | 190.00 | 0.5334 | Terdominasi |
+| Patience Sort | 248.80 | 0.4926 | Terdominasi |
+| Binary Insertion | 529.90 | 0.8834 | Terdominasi |
+| Tournament Sort | 557.00 | 0.8855 | Terdominasi |
+| Tree Sort | 643.60 | 0.8367 | Terdominasi |
+| Quicksort | 651.10 | 0.8354 | Terdominasi |
+| Strand Sort | 774.50 | 0.8265 | Terdominasi |
+| Hayate-Shiki | 980.50 | 0.7909 | Terdominasi |
+| Bitonic Sort | 1334.00 | 0.9526 | Terdominasi |
+| Insertion Sort | 2556.60 | 0.8041 | Terdominasi |
+| Cocktail Shaker | 3873.70 | 0.9777 | Terdominasi |
+| Odd-Even Sort | 4702.50 | 0.9884 | Terdominasi |
+| Gnome Sort | 4911.80 | 0.9581 | Terdominasi |
+| Bubble Sort | 4917.30 | 0.9731 | Terdominasi |
+| Selection Sort | 4950.00 | 0.9344 | Terdominasi |
+| Stooge Sort | 4950.00 | 0.2826 | Terdominasi |
+| Bogosort | 4950.00 | 0.9781 | Terdominasi |
+| Cycle Sort | 4950.00 | 0.4720 | Terdominasi |
+| Slowsort | 4950.00 | 0.4357 | Terdominasi |
+| Pancake Sort | 4950.00 | 0.9761 | Terdominasi |
+| Bozosort | 4950.00 | 0.5962 | Terdominasi |
+| BogoBogoSort | 4950.00 | 0.0975 | Terdominasi |
 
 ### Analisis Pareto Frontier & Titik Lutut
 Pareto Frontier mengidentifikasi algoritma di mana tidak ada algoritma lain yang lebih baik dalam meminimalkan pertarungan sekaligus lebih baik dalam memaksimalkan akurasi.

--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -17,39 +17,40 @@ The table is partitioned by Pareto status and sorted by Avg Battles (ascending),
 
 | Algorithm | Avg Battles | Avg Kendall Tau | Pareto Status |
 | :--- | :--- | :--- | :--- |
-| Intelligent Design | 0.00 | 0.0331 | Pareto-optimal |
-| Miracle Sort | 99.00 | 0.5165 | Pareto-optimal |
-| Thanos Sort | 190.00 | 0.5265 | Pareto-optimal |
-| Intro Sort | 445.40 | 0.8566 | Pareto-optimal |
-| Ford-Johnson | 525.70 | 0.8937 | Pareto-optimal |
-| Binary Insertion | 529.90 | 0.8953 | Pareto-optimal |
-| Merge Sort | 543.80 | 0.9049 | Pareto-optimal |
-| **Shellsort** | **719.50** | **0.9446** | **Production Knee Point** |
-| Comb Sort | 1201.00 | 0.9897 | Pareto-optimal |
+| Intelligent Design | 0.00 | 0.0324 | Pareto-optimal |
+| Miracle Sort | 99.00 | 0.5413 | Pareto-optimal |
+| Smooth Sort | 170.20 | 0.5445 | Pareto-optimal |
+| Intro Sort | 456.80 | 0.8465 | Pareto-optimal |
+| Ford-Johnson | 526.20 | 0.8879 | Pareto-optimal |
+| Merge Sort | 542.10 | 0.8985 | Pareto-optimal |
+| **Shellsort** | **743.30** | **0.9387** | **Production Knee Point** |
+| Comb Sort | 1230.70 | 0.9905 | Pareto-optimal |
 | Full Rank | 4950.00 | 1.0000 | Pareto-optimal |
-| Quantum Bogo | 1.40 | -0.0349 | Dominated |
-| Stalin Sort | 99.00 | 0.1055 | Dominated |
-| Smooth Sort | 147.00 | 0.4847 | Dominated |
-| Heap Sort | 147.20 | 0.4650 | Dominated |
-| Patience Sort | 243.70 | 0.4525 | Dominated |
-| Tournament Sort | 556.40 | 0.8895 | Dominated |
-| Tree Sort | 598.10 | 0.8354 | Dominated |
-| Quicksort | 647.20 | 0.8359 | Dominated |
-| Strand Sort | 705.50 | 0.8321 | Dominated |
-| Bitonic Sort | 1334.00 | 0.9477 | Dominated |
-| Insertion Sort | 2581.00 | 0.8063 | Dominated |
-| Cocktail Shaker | 4011.00 | 0.9802 | Dominated |
-| Odd-Even Sort | 4682.70 | 0.9896 | Dominated |
-| Bubble Sort | 4884.40 | 0.9709 | Dominated |
-| Gnome Sort | 4895.60 | 0.9660 | Dominated |
-| Selection Sort | 4950.00 | 0.9339 | Dominated |
-| Bogosort | 4950.00 | 0.9789 | Dominated |
-| Pancake Sort | 4950.00 | 0.9762 | Dominated |
-| Bozosort | 4950.00 | 0.5992 | Dominated |
-| Slowsort | 4950.00 | 0.4645 | Dominated |
-| Cycle Sort | 4950.00 | 0.3362 | Dominated |
-| Stooge Sort | 4950.00 | 0.3124 | Dominated |
-| BogoBogoSort | 4950.00 | 0.0487 | Dominated |
+| Quantum Bogo | 1.70 | 0.0230 | Dominated |
+| Stalin Sort | 99.00 | 0.0640 | Dominated |
+| Heap Sort | 164.30 | 0.4808 | Dominated |
+| Thanos Sort | 190.00 | 0.5334 | Dominated |
+| Patience Sort | 248.80 | 0.4926 | Dominated |
+| Binary Insertion | 529.90 | 0.8834 | Dominated |
+| Tournament Sort | 557.00 | 0.8855 | Dominated |
+| Tree Sort | 643.60 | 0.8367 | Dominated |
+| Quicksort | 651.10 | 0.8354 | Dominated |
+| Strand Sort | 774.50 | 0.8265 | Dominated |
+| Hayate-Shiki | 980.50 | 0.7909 | Dominated |
+| Bitonic Sort | 1334.00 | 0.9526 | Dominated |
+| Insertion Sort | 2556.60 | 0.8041 | Dominated |
+| Cocktail Shaker | 3873.70 | 0.9777 | Dominated |
+| Odd-Even Sort | 4702.50 | 0.9884 | Dominated |
+| Gnome Sort | 4911.80 | 0.9581 | Dominated |
+| Bubble Sort | 4917.30 | 0.9731 | Dominated |
+| Selection Sort | 4950.00 | 0.9344 | Dominated |
+| Stooge Sort | 4950.00 | 0.2826 | Dominated |
+| Bogosort | 4950.00 | 0.9781 | Dominated |
+| Cycle Sort | 4950.00 | 0.4720 | Dominated |
+| Slowsort | 4950.00 | 0.4357 | Dominated |
+| Pancake Sort | 4950.00 | 0.9761 | Dominated |
+| Bozosort | 4950.00 | 0.5962 | Dominated |
+| BogoBogoSort | 4950.00 | 0.0975 | Dominated |
 
 ### Pareto Frontier & Knee Point Analysis
 The Pareto Frontier identifies algorithms where no other algorithm is both better at minimizing battles and better at maximizing accuracy.

--- a/README-id.md
+++ b/README-id.md
@@ -22,12 +22,12 @@ Berdasarkan analisis komparatif terhadap 24 algoritma pengurutan (lihat [ANALYSI
 **Perbandingan (N=100):**
 | Algoritma | Rata-rata Pertarungan | Rata-rata Kendall Tau | Status Pareto |
 | :--- | :--- | :--- | :--- |
-| Heap Sort | ~165 | 0.49 | Pareto-optimal |
-| Ford-Johnson | ~527 | 0.89 | Pareto-optimal |
-| Merge Sort | ~543 | 0.91 | Pareto-optimal |
-| **Shellsort** | **~725** | **0.95** | **Titik Lutut** |
-| Comb Sort | ~1260 | 0.99 | Pareto-optimal |
-| Full Rank | 4950 | 1.00 | Pareto-optimal |
+| Smooth Sort | ~170 | 0.54 | Pareto-optimal |
+| Ford-Johnson | ~526 | 0.88 | Pareto-optimal |
+| Merge Sort | ~542 | 0.89 | Pareto-optimal |
+| **Shellsort** | **~743** | **0.93** | **Titik Lutut** |
+| Comb Sort | ~1230 | 0.99 | Pareto-optimal |
+| Full Rank | ~4950 | 1.00 | Pareto-optimal |
 
 *Peringkat Cepat mengurangi pertarungan sekitar 85% dibandingkan dengan Peringkat Penuh sambil tetap mempertahankan akurasi peringkat yang tinggi. Algoritma seperti Bogosort secara kuantitatif absurd dan hanya berfungsi sebagai pembanding yang lucu.*
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Based on a comparative analysis of 24 sorting algorithms (see [ANALYSIS.md](ANAL
 **Comparison (N=100):**
 | Algorithm | Avg Battles | Avg Kendall Tau | Pareto Status |
 | :--- | :--- | :--- | :--- |
-| Heap Sort | ~165 | 0.49 | Pareto-optimal |
-| Ford-Johnson | ~527 | 0.89 | Pareto-optimal |
-| Merge Sort | ~543 | 0.91 | Pareto-optimal |
-| **Shellsort** | **~725** | **0.95** | **Knee Point** |
-| Comb Sort | ~1260 | 0.99 | Pareto-optimal |
-| Full Rank | 4950 | 1.00 | Pareto-optimal |
+| Smooth Sort | ~170 | 0.54 | Pareto-optimal |
+| Ford-Johnson | ~526 | 0.88 | Pareto-optimal |
+| Merge Sort | ~542 | 0.89 | Pareto-optimal |
+| **Shellsort** | **~743** | **0.93** | **Knee Point** |
+| Comb Sort | ~1230 | 0.99 | Pareto-optimal |
+| Full Rank | ~4950 | 1.00 | Pareto-optimal |
 
 *Quick Rank reduces battles by ~85% compared to Full Rank while maintaining high ranking accuracy. Algorithms like Bogosort are quantitatively absurd and serve only as a humorous baseline.*
 

--- a/benchmark_results.txt
+++ b/benchmark_results.txt
@@ -1,0 +1,36 @@
+Simulating N=100, trials=10
+Algorithm	Avg Battles	Avg Kendall Tau
+Ford-Johnson	526.20	0.8879
+Merge Sort	542.10	0.8985
+Hayate-Shiki	980.50	0.7909
+Shellsort	743.30	0.9387
+Quicksort	651.10	0.8354
+Bubble Sort	4917.30	0.9731
+Selection Sort	4950.00	0.9344
+Insertion Sort	2556.60	0.8041
+Binary Insertion	529.90	0.8834
+Gnome Sort	4911.80	0.9581
+Stooge Sort	4950.00	0.2826
+Bogosort	4950.00	0.9781
+Full Rank	4950.00	1.0000
+Cycle Sort	4950.00	0.4720
+Bitonic Sort	1334.00	0.9526
+Heap Sort	164.30	0.4808
+Comb Sort	1230.70	0.9905
+Tournament Sort	557.00	0.8855
+Odd-Even Sort	4702.50	0.9884
+Slowsort	4950.00	0.4357
+Pancake Sort	4950.00	0.9761
+Cocktail Shaker	3873.70	0.9777
+Bozosort	4950.00	0.5962
+Tree Sort	643.60	0.8367
+BogoBogoSort	4950.00	0.0975
+Stalin Sort	99.00	0.0640
+Thanos Sort	190.00	0.5334
+Miracle Sort	99.00	0.5413
+Intelligent Design	0.00	0.0324
+Quantum Bogo	1.70	0.0230
+Intro Sort	456.80	0.8465
+Strand Sort	774.50	0.8265
+Patience Sort	248.80	0.4926
+Smooth Sort	170.20	0.5445

--- a/pareto_output.txt
+++ b/pareto_output.txt
@@ -1,0 +1,37 @@
+Pareto-optimal algorithms (N=100):
+  Intelligent Design                battles=    0.00  tau=0.0324
+  Miracle Sort                      battles=   99.00  tau=0.5413
+  Smooth Sort                       battles=  170.20  tau=0.5445
+  Intro Sort                        battles=  456.80  tau=0.8465
+  Ford-Johnson                      battles=  526.20  tau=0.8879
+  Merge Sort                        battles=  542.10  tau=0.8985
+  Shellsort                         battles=  743.30  tau=0.9387  <-- PROD  <-- MATH KNEE
+  Comb Sort                         battles= 1230.70  tau=0.9905
+  Full Rank                         battles= 4950.00  tau=1.0000
+
+Dominated algorithms:
+  Quantum Bogo                      battles=    1.70  tau=0.0230
+  Stalin Sort                       battles=   99.00  tau=0.0640
+  Heap Sort                         battles=  164.30  tau=0.4808
+  Thanos Sort                       battles=  190.00  tau=0.5334
+  Patience Sort                     battles=  248.80  tau=0.4926
+  Binary Insertion                  battles=  529.90  tau=0.8834
+  Tournament Sort                   battles=  557.00  tau=0.8855
+  Tree Sort                         battles=  643.60  tau=0.8367
+  Quicksort                         battles=  651.10  tau=0.8354
+  Strand Sort                       battles=  774.50  tau=0.8265
+  Hayate-Shiki                      battles=  980.50  tau=0.7909
+  Bitonic Sort                      battles= 1334.00  tau=0.9526
+  Insertion Sort                    battles= 2556.60  tau=0.8041
+  Cocktail Shaker                   battles= 3873.70  tau=0.9777
+  Odd-Even Sort                     battles= 4702.50  tau=0.9884
+  Gnome Sort                        battles= 4911.80  tau=0.9581
+  Bubble Sort                       battles= 4917.30  tau=0.9731
+  Selection Sort                    battles= 4950.00  tau=0.9344
+  Stooge Sort                       battles= 4950.00  tau=0.2826
+  Bogosort                          battles= 4950.00  tau=0.9781
+  Cycle Sort                        battles= 4950.00  tau=0.4720
+  Slowsort                          battles= 4950.00  tau=0.4357
+  Pancake Sort                      battles= 4950.00  tau=0.9761
+  Bozosort                          battles= 4950.00  tau=0.5962
+  BogoBogoSort                      battles= 4950.00  tau=0.0975

--- a/research/pareto_analysis.js
+++ b/research/pareto_analysis.js
@@ -1,13 +1,7 @@
 
-const algos = [
-    "Ford-Johnson", "Merge Sort", "Shellsort", "Quicksort", "Bubble Sort", "Selection Sort", "Insertion Sort",
-    "Binary Insertion", "Gnome Sort", "Stooge Sort", "Bogosort", "Full Rank", "Cycle Sort", "Bitonic Sort",
-    "Heap Sort", "Comb Sort", "Tournament Sort", "Odd-Even Sort", "Slowsort", "Pancake Sort", "Cocktail Shaker",
-    "Bozosort", "Tree Sort", "BogoBogoSort", "Stalin Sort", "Thanos Sort", "Miracle Sort", "Intelligent Design",
-    "Quantum Bogo", "Intro Sort", "Strand Sort", "Patience Sort", "Smooth Sort"
-];
-const battles = [525.70, 543.80, 719.50, 647.20, 4884.40, 4950.00, 2581.00, 529.90, 4895.60, 4950.00, 4950.00, 4950.00, 4950.00, 1334.00, 147.20, 1201.00, 556.40, 4682.70, 4950.00, 4950.00, 4011.00, 4950.00, 598.10, 4950.00, 99.00, 190.00, 99.00, 0.00, 1.40, 445.40, 705.50, 243.70, 147.00];
-const tau     = [0.8937, 0.9049, 0.9446, 0.8359, 0.9709, 0.9339, 0.8063, 0.8953, 0.9660, 0.3124, 0.9789, 1.0000, 0.3362, 0.9477, 0.4650, 0.9897, 0.8895, 0.9896, 0.4645, 0.9762, 0.9802, 0.5992, 0.8354, 0.0487, 0.1055, 0.5265, 0.5165, 0.0331, -0.0349, 0.8566, 0.8321, 0.4525, 0.4847];
+const algos = ["Ford-Johnson", "Merge Sort", "Hayate-Shiki", "Shellsort", "Quicksort", "Bubble Sort", "Selection Sort", "Insertion Sort", "Binary Insertion", "Gnome Sort", "Stooge Sort", "Bogosort", "Full Rank", "Cycle Sort", "Bitonic Sort", "Heap Sort", "Comb Sort", "Tournament Sort", "Odd-Even Sort", "Slowsort", "Pancake Sort", "Cocktail Shaker", "Bozosort", "Tree Sort", "BogoBogoSort", "Stalin Sort", "Thanos Sort", "Miracle Sort", "Intelligent Design", "Quantum Bogo", "Intro Sort", "Strand Sort", "Patience Sort", "Smooth Sort"];
+const battles = [526.20, 542.10, 980.50, 743.30, 651.10, 4917.30, 4950.00, 2556.60, 529.90, 4911.80, 4950.00, 4950.00, 4950.00, 4950.00, 1334.00, 164.30, 1230.70, 557.00, 4702.50, 4950.00, 4950.00, 3873.70, 4950.00, 643.60, 4950.00, 99.00, 190.00, 99.00, 0.00, 1.70, 456.80, 774.50, 248.80, 170.20];
+const tau     = [0.8879, 0.8985, 0.7909, 0.9387, 0.8354, 0.9731, 0.9344, 0.8041, 0.8834, 0.9581, 0.2826, 0.9781, 1.0000, 0.4720, 0.9526, 0.4808, 0.9905, 0.8855, 0.9884, 0.4357, 0.9761, 0.9777, 0.5962, 0.8367, 0.0975, 0.0640, 0.5334, 0.5413, 0.0324, 0.0230, 0.8465, 0.8265, 0.4926, 0.5445];
 
 function pareto_mask(x, y) {
     const n = x.length, mask = new Array(n).fill(true);

--- a/research/sort_analysis.js
+++ b/research/sort_analysis.js
@@ -442,6 +442,127 @@ class SmoothSortProvider extends Provider {
     }
 }
 
+class HayateShikiProvider extends Provider {
+    constructor(n) { super(n); this.cnIns = 32; this.iSrc = 0; this.unitStack = []; this.nJoin = 0; this.state = 'MAKE_UNIT'; this.external = new Array(n); this.mergeTasks = []; this.mpSubState = null; }
+    next(result) {
+        while (true) {
+            if (this.mergeTasks.length > 0) {
+                const t = this.mergeTasks[this.mergeTasks.length - 1];
+                if (t.state === 'INIT') { t.res = []; t.i = 0; t.j = 0; t.state = 'COMPARE'; }
+                if (t.state === 'COMPARE') {
+                    if (result !== undefined) { if (result === 1) t.res.push(t.u1[t.i++]); else t.res.push(t.u2[t.j++]); result = undefined; }
+                    if (t.i < t.u1.length && t.j < t.u2.length) return [t.u1[t.i], t.u2[t.j]];
+                    const merged = t.res.concat(t.u1.slice(t.i)).concat(t.u2.slice(t.j));
+                    this.mergeTasks.pop(); if (t.callback) t.callback(merged); continue;
+                }
+            }
+            if (this.state === 'MAKE_UNIT') { if (this.iSrc >= this.n) { this.state = 'FINAL_MERGE'; continue; } this.state = 'MAKE_PART_0'; continue; }
+            if (this.state === 'MAKE_PART_0') {
+                const res = this.subMakePart(result); if (res === 'BUSY') return this.lastPair;
+                const unit0 = this.partToUnit(res); result = undefined;
+                if (this.iSrc >= this.n) { this.pushUnit(unit0); this.state = 'MAKE_UNIT'; continue; }
+                this.unit0 = unit0; this.state = 'MAKE_PART_1'; continue;
+            }
+            if (this.state === 'MAKE_PART_1') {
+                const res = this.subMakePart(result); if (res === 'BUSY') return this.lastPair;
+                const unit1 = this.partToUnit(res); result = undefined;
+                this.mergeTasks.push({ u1: this.unit0, u2: unit1, state: 'INIT', callback: (merged) => this.pushUnit(merged) });
+                this.state = 'MAKE_UNIT'; continue;
+            }
+            if (this.state === 'FINAL_MERGE') {
+                if (this.unitStack.length > 1) {
+                    const u2 = this.unitStack.pop(), u1 = this.unitStack.pop();
+                    this.mergeTasks.push({ u1, u2, state: 'INIT', callback: (merged) => this.unitStack.push(merged) }); continue;
+                }
+                if (this.unitStack.length > 0) this.items = this.unitStack[0]; return null;
+            }
+        }
+    }
+    subMakePart(result) {
+        if (!this.mpSubState) { this.mpSubState = 'INIT'; this.mpA = this.iSrc; this.mpE = this.iSrc; this.isDsc = false; }
+        while (true) {
+            if (this.mpSubState === 'INIT') {
+                if (this.iSrc + 1 < this.n) { this.mpSubState = 'DECIDE'; this.lastPair = [this.items[this.iSrc + 1], this.items[this.iSrc]]; return 'BUSY'; }
+                this.iSrc++; this.mpE = this.iSrc; this.mpSubState = 'EXTEND_RUN_END'; continue;
+            }
+            if (this.mpSubState === 'DECIDE') { this.isDsc = (result === 0); this.mpE = Math.min(this.mpA + this.cnIns, this.n); this.mpInsI = this.mpA + 1; this.mpSubState = 'INS_SORT_START'; result = undefined; continue; }
+            if (this.mpSubState === 'INS_SORT_START') {
+                if (this.mpInsI < this.mpE) { this.mpInsVal = this.items[this.mpInsI]; this.mpInsJ = this.mpInsI - 1; this.mpSubState = 'INS_SORT_COMPARE'; continue; }
+                this.iSrc = this.mpE; this.mpSubState = 'EXTEND_RUN'; continue;
+            }
+            if (this.mpSubState === 'INS_SORT_COMPARE') {
+                if (this.mpInsJ >= this.mpA) { this.lastPair = [this.mpInsVal, this.items[this.mpInsJ]]; this.mpSubState = 'INS_SORT_RESULT'; return 'BUSY'; }
+                this.items[this.mpInsJ + 1] = this.mpInsVal; this.mpInsI++; this.mpSubState = 'INS_SORT_START'; continue;
+            }
+            if (this.mpSubState === 'INS_SORT_RESULT') {
+                const cond = this.isDsc ? (result === 1) : (result === 0);
+                if (cond) { this.items[this.mpInsJ + 1] = this.items[this.mpInsJ]; this.mpInsJ--; this.mpSubState = 'INS_SORT_COMPARE'; }
+                else { this.items[this.mpInsJ + 1] = this.mpInsVal; this.mpInsI++; this.mpSubState = 'INS_SORT_START'; }
+                result = undefined; continue;
+            }
+            if (this.mpSubState === 'EXTEND_RUN') {
+                if (this.iSrc < this.mpE) this.iSrc = this.mpE;
+                if (this.iSrc < this.n) { this.lastPair = [this.items[this.iSrc], this.items[this.iSrc - 1]]; this.mpSubState = 'EXTEND_RUN_RESULT'; return 'BUSY'; }
+                this.mpSubState = 'EXTEND_RUN_END'; continue;
+            }
+            if (this.mpSubState === 'EXTEND_RUN_RESULT') {
+                const cond = this.isDsc ? (result === 0) : (result === 1);
+                if (cond) { this.iSrc++; this.mpE = this.iSrc; this.mpSubState = 'EXTEND_RUN'; }
+                else { this.mpSubState = 'EXTEND_RUN_END'; }
+                result = undefined; continue;
+            }
+            if (this.mpSubState === 'EXTEND_RUN_END') {
+                if (this.isDsc) { let l = this.mpA, r = this.mpE - 1; while (l < r) { [this.items[l], this.items[r]] = [this.items[r], this.items[l]]; l++; r--; } }
+                this.mpSubState = 'EXTEND_EXTERNAL_INIT'; continue;
+            }
+            if (this.mpSubState === 'EXTEND_EXTERNAL_INIT') {
+                this.mpADsc = this.n; this.mpEDsc = this.n;
+                if (this.iSrc < this.n) { this.lastPair = [this.items[this.iSrc], this.items[this.mpA]]; this.mpSubState = 'EXTEND_EXTERNAL_RESULT_MIN'; return 'BUSY'; }
+                this.mpSubState = 'DONE'; continue;
+            }
+            if (this.mpSubState === 'EXTEND_EXTERNAL_RESULT_MIN') {
+                if (result === 0) { this.external[--this.mpADsc] = this.items[this.iSrc++]; this.mpSubState = 'EXTEND_EXTERNAL_LOOP'; }
+                else { this.mpSubState = 'DONE'; }
+                result = undefined; continue;
+            }
+            if (this.mpSubState === 'EXTEND_EXTERNAL_LOOP') {
+                if (this.iSrc < this.n) { this.lastPair = [this.items[this.iSrc], this.items[this.mpE - 1]]; this.mpSubState = 'EXTEND_EXTERNAL_LOOP_MAX'; return 'BUSY'; }
+                this.mpSubState = 'DONE'; continue;
+            }
+            if (this.mpSubState === 'EXTEND_EXTERNAL_LOOP_MAX') {
+                if (result === 1) { this.items[this.mpE++] = this.items[this.iSrc++]; this.mpSubState = 'EXTEND_EXTERNAL_LOOP'; }
+                else { this.lastPair = [this.items[this.iSrc], this.external[this.mpADsc]]; this.mpSubState = 'EXTEND_EXTERNAL_LOOP_MIN'; return 'BUSY'; }
+                result = undefined; continue;
+            }
+            if (this.mpSubState === 'EXTEND_EXTERNAL_LOOP_MIN') {
+                if (result === 0) { this.external[--this.mpADsc] = this.items[this.iSrc++]; this.mpSubState = 'EXTEND_EXTERNAL_LOOP'; }
+                else { this.mpSubState = 'DONE'; }
+                result = undefined; continue;
+            }
+            if (this.mpSubState === 'DONE') {
+                const res = { aAsc: this.mpA, nAsc: this.mpE - this.mpA, aDsc: this.mpADsc, nDsc: this.mpEDsc - this.mpADsc };
+                this.mpSubState = null; return res;
+            }
+        }
+    }
+    partToUnit(p) {
+        const res = [];
+        for (let i = 0; i < p.nDsc; i++) res.push(this.external[p.aDsc + i]);
+        for (let i = 0; i < p.nAsc; i++) res.push(this.items[p.aAsc + i]);
+        return res;
+    }
+    pushUnit(unit) {
+        this.unitStack.push(unit); let n = this.nJoin++; let carry = (n ^ (n + 1)) & n;
+        this.performIterativeMerge(carry);
+    }
+    performIterativeMerge(carry) {
+        if (carry > 0 && this.unitStack.length > 1) {
+            const u2 = this.unitStack.pop(), u1 = this.unitStack.pop();
+            this.mergeTasks.push({ u1, u2, state: 'INIT', callback: (merged) => { this.unitStack.push(merged); this.performIterativeMerge(carry >> 1); } });
+        }
+    }
+}
+
 class StalinSortProvider extends Provider {
     constructor(n) { super(n); this.i = 1; }
     next(result) {
@@ -584,6 +705,7 @@ function simulate(n, ProviderClass, trials = 10) {
 
 const N = 100, algos = [
     { name: 'Ford-Johnson', class: FJProvider }, { name: 'Merge Sort', class: MergeSortProvider },
+    { name: 'Hayate-Shiki', class: HayateShikiProvider },
     { name: 'Shellsort', class: ShellSortProvider }, { name: 'Quicksort', class: QuicksortProvider },
     { name: 'Bubble Sort', class: BubbleSortProvider }, { name: 'Selection Sort', class: SelectionSortProvider },
     { name: 'Insertion Sort', class: InsertionSortProvider }, { name: 'Binary Insertion', class: BinaryInsertionSortProvider },


### PR DESCRIPTION
Include the Hayate-Shiki sorting algorithm in the benchmark and update all documentation with a fresh recalculation of results for all 34 algorithms at N=100.

---
*PR created automatically by Jules for task [14786249957228247582](https://jules.google.com/task/14786249957228247582) started by @mahalisyarifuddin*