### PR TITLE
🩺 Medic: Fix malformed adjacency matrix upon session load

### DIFF
--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1285,6 +1285,7 @@
 				}
 				restoreBattle(battle) {
 					Object.assign(this, battle);
+					this.dirty = true;
 					this.showGrade = !!battle.showGrade;
 					elements.showGrade.checked = this.showGrade;
 					this.scores = Object.values(battle.scores);


### PR DESCRIPTION
When restoring a session from localStorage, TypedArrays (such as `Int32Array`) in `this.adj` lose their type and length since JSON converts them into plain objects. If `this.dirty` was stored as `false`, `recalculateScores()` returns early. As a result, when `Stats.calculate` invokes `buildHessian`, `adj[i].length` returns `undefined`, which breaks the generation of Confidence Intervals (CI) and spreads.

By forcibly setting `this.dirty = true` in `restoreBattle()`, the `adj` matrix is regenerated safely on load. This completely resolves the bug and prevents crashes.

---
*PR created automatically by Jules for task [14648692560785165264](https://jules.google.com/task/14648692560785165264) started by @mahalisyarifuddin*