### PR TITLE
🩺 Medic: Fix QuickPairProvider tie handling in merge sort

### DIFF
--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1080,7 +1080,7 @@
 						}
 						if (f.state === 3) {
 							if (result !== undefined) {
-								if (result === 1) this.items[f.k++] = f.leftArr[f.i++];
+								if (result >= 0.5) this.items[f.k++] = f.leftArr[f.i++];
 								else this.items[f.k++] = f.rightArr[f.j++];
 								result = undefined;
 							}


### PR DESCRIPTION
🔍 Diagnosis: The `QuickPairProvider` inside `PreferenceRank.html` failed to handle ties (`result === 0.5`) properly. It had a strict check `if (result === 1)` to pick from the left array. If it was a tie, it fell through to the `else` block and picked from the right array, introducing instability in the merge sort process.
📍 Location: `PreferenceRank.html` (inside `QuickPairProvider.next()`)
💥 Symptoms: Ties during Quick Rank would incorrectly prioritize the right element, violating Bradley-Terry tie assumptions and breaking the stability of the underlying merge sort.
💉 Treatment: Changed `if (result === 1)` to `if (result >= 0.5)`, ensuring that primary items (1) or ties (0.5) correctly prioritize the left array.
🧪 Test: Visually confirmed ties via Playwright frontend verification. Ran `node research/sort_analysis.js` to verify no regressions in overall benchmark scores.

---
*PR created automatically by Jules for task [4928372112758204985](https://jules.google.com/task/4928372112758204985) started by @mahalisyarifuddin*