### PR TITLE
🩺 Medic: Fix XSS in filter input

### DIFF
--- a/.jules/codecraft.md
+++ b/.jules/codecraft.md
@@ -2,3 +2,8 @@
 **Mode:** Palette
 **Learning:** Testing tools like playwright should not be installed via `npm` or have their artifacts (`package.json`, `.gitignore`, `test.js`) left behind unless explicitly authorized by the project structure. If a project does not have testing tools already, adding them can violate boundaries.
 **Action:** Do not use `npm` or `yarn` (only `pnpm` if present), and do not commit or leave behind ad-hoc test files or unapproved dependencies when performing manual frontend verification. Verify frontend changes visually using tools like browser or playwright but remove artifacts prior to submit.
+
+## 2024-05-24 - Do not inject user input into innerHTML without sanitization
+**Mode:** Medic
+**Learning:** In vanilla JS projects, interpolating user inputs into an `innerHTML` string (e.g. `div.innerHTML = "<input value='" + userInput + "'>"`) exposes an XSS vulnerability.
+**Action:** When dynamically constructing HTML nodes that require user input values, either create the node with `innerHTML` lacking the value and then explicitly set `element.value = userInput`, or use proper DOM element creation techniques (e.g., `document.createElement`). Ensure no ad-hoc tests (like JS files or `package.json` configurations generated for verifying the XSS fix) are left behind.

--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1582,7 +1582,8 @@
 					elements.results.appendChild(headerWrapper);
 					const filterDiv = document.createElement('div');
 					filterDiv.className = 'filter-wrap';
-					filterDiv.innerHTML = `<input type="search" id="resultFilter" placeholder="${this.string('filter')}" aria-label="${this.string('filter')}" value="${this.filterTerm || ''}">`;
+					filterDiv.innerHTML = `<input type="search" id="resultFilter" placeholder="${this.string('filter')}" aria-label="${this.string('filter')}">`;
+					filterDiv.firstChild.value = this.filterTerm || '';
 					elements.results.appendChild(filterDiv);
 					elements.results.appendChild(elements.showGradeRow);
 					elements.showGradeRow.classList.remove('hidden');


### PR DESCRIPTION
🩺 Medic: Fix XSS in filter input

🔍 Diagnosis: In `PreferenceRank.html`, the user's filter search term was directly interpolated via a template literal into the `innerHTML` string used to build the result filter search bar. This permitted XSS attacks via payloads such as `"> <img src=x onerror=alert(1)>`.
📍 Location: `PreferenceRank.html`, line 1585.
💥 Symptoms: Potential Cross-Site Scripting (XSS) allowing execution of arbitrary code when searching items.
💉 Treatment: Instead of string interpolation for the value, the `<input>` element is generated without a preset value attribute, and the value is safely assigned programmatically using `.value = this.filterTerm || ''`. This method sanitizes user input natively.
🧪 Test: Created a temporary Node.js test simulating the XSS exploit and verified that the malicious string is no longer processed as HTML tags, and removed temporary files prior to PR creation.

---
*PR created automatically by Jules for task [3385399897720724801](https://jules.google.com/task/3385399897720724801) started by @mahalisyarifuddin*