### PR TITLE
🩺 Medic: Fix NaN estimate for zero items in Quick Rank

### DIFF
--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1048,6 +1048,7 @@
 			}
 			class QuickPairProvider {
 				static estimate(n) {
+					if (n === 0) return 0;
 					return Math.round(n * Math.log2(n) - n + 1);
 				}
 				constructor(count) {


### PR DESCRIPTION
Fixes a bug where `0` items in the text area caused the Quick Rank comparison estimate to display `~NaN comparisons`. This happened because `0 * Math.log2(0)` equals `NaN`. Adding an early return correctly displays `~0 comparisons`.

---
*PR created automatically by Jules for task [18186055566721870465](https://jules.google.com/task/18186055566721870465) started by @mahalisyarifuddin*