### PR TITLE
🩺 Medic: Fix XSS vulnerability in item results string generation

### DIFF
--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1668,7 +1668,7 @@
 						row.innerHTML = `
 						<div class="lb-main" role="button" tabindex="0" aria-expanded="false">
 							<div class="lb-col-rank"><span class="chevron" aria-hidden="true">&#x203a;</span><span>${rank}</span></div>
-							<div class="lb-col-item">${new Option(item).innerHTML}</div>
+							<div class="lb-col-item"></div>
 							${this.showGrade ? `<div class="lb-col-grade">${this.getGrade(score)}</div>` : ''}
 							<div class="lb-col-score">${score}${ci !== null ? `<span class="ci-badge">±${ci}</span>` : ''}</div>
 						</div>
@@ -1678,6 +1678,7 @@
 								<div class="detail-item"><span class="detail-label">${this.string('matches')}</span><span class="detail-value">${itemMatches[x]}</span></div>
 							</div>
 						</div>`;
+						row.querySelector('.lb-col-item').textContent = item;
 						const main = row.querySelector('.lb-main');
 						const toggle = ()=>{
 							const isExpanded = row.classList.toggle('expanded');


### PR DESCRIPTION
This PR addresses a Cross-Site Scripting (XSS) vulnerability found during a "Medic" mode code audit.

🔍 Diagnosis: The `results` method dynamically generated the HTML string for leaderboard rows using `new Option(item).innerHTML` within a template literal. While `Option` inherently escapes some characters, direct injection of user-controlled variables into an `innerHTML` string pattern is flagged as a systemic risk and violates established codebase boundaries defined in the `.jules/codecraft.md` journal.

📍 Location: `PreferenceRank.html`, around line 1671 inside the `.lb-col-item` generation.

💥 Symptoms: Potential attack vector if escaping mechanisms via `Option` were incomplete or modified, exposing the application to script injections from malicious items.

💉 Treatment: Rewrote the DOM update pattern. Instead of rendering the `item` value directly inside the `row.innerHTML` template string, an empty `<div class="lb-col-item"></div>` container is rendered first. Afterwards, the DOM element is selected via `row.querySelector('.lb-col-item')`, and the user's item string is securely assigned directly to the `textContent` property, bypassing HTML parsing completely and natively guaranteeing XSS safety.

🧪 Test: Verified manually using Node.js DOM construction simulations and `grep` assertions to ensure no HTML-interpolated user-string remnants were left behind in the final rendering logic. Evaluated the absence of automated tests via `pnpm lint/test` checks (no `package.json` exists in the repo) and ensured clean manual execution.

---
*PR created automatically by Jules for task [10301006867574888095](https://jules.google.com/task/10301006867574888095) started by @mahalisyarifuddin*