### PR TITLE
🩺 Medic: Fix crash when resuming Quick Rank sessions

### DIFF
--- a/.jules/codecraft.md
+++ b/.jules/codecraft.md
@@ -7,3 +7,8 @@
 **Mode:** Medic
 **Learning:** In vanilla JS projects, interpolating user inputs into an `innerHTML` string (e.g. `div.innerHTML = "<input value='" + userInput + "'>"`) exposes an XSS vulnerability.
 **Action:** When dynamically constructing HTML nodes that require user input values, either create the node with `innerHTML` lacking the value and then explicitly set `element.value = userInput`, or use proper DOM element creation techniques (e.g., `document.createElement`). Ensure no ad-hoc tests (like JS files or `package.json` configurations generated for verifying the XSS fix) are left behind.
+
+## 2024-05-24 - QuickPairProvider State Restoration
+**Mode:** Medic
+**Learning:** `QuickPairProvider` manages its execution via a serializable state stack and plain object properties, unlike previous sorting providers that relied on replaying history via `_start()` or `restore()`. Therefore, it can be directly hydrated from `localStorage` using `Object.assign`. Calling the non-existent `_start` or the improperly functioning `restore` causes the app to crash or lose state when resuming a session.
+**Action:** When restoring provider state for new algorithms in `restoreBattle`, rely on flat property assignment if the provider was designed to cleanly serialize its internal state to the `localStorage` payload, avoiding the invocation of specialized lifecycle methods that are no longer part of the provider's API.

--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1297,12 +1297,7 @@
 					elements.showGrade.checked = this.showGrade;
 					this.scores = Object.values(battle.scores);
 					this.provider = new (battle.providerType === 'quick' ? QuickPairProvider : FullPairProvider)(this.items.length);
-					if (battle.providerType === 'quick') {
-						const last = this.history[this.history.length - 1];
-						last ? this.provider.restore(last.state, this.matches) : this.provider._start(this.matches);
-					} else {
-						Object.assign(this.provider, battle.provider);
-					}
+					Object.assign(this.provider, battle.provider);
 					elements.allowTies.checked = this.allowTies;
 					elements.quickRank.checked = battle.providerType === 'quick';
 					this.setTies(this.allowTies);


### PR DESCRIPTION
🩺 Medic: Fix crash when resuming Quick Rank sessions

🔍 Diagnosis: When a user attempts to resume a previously saved "Quick Rank" session, the application crashes with a `TypeError: this.provider._start is not a function`. This occurs because the previous provider implementation (`PrismChainProvider`) used `_start` and `restore` methods, but the new `QuickPairProvider` manages its state internally via a stack and doesn't implement `_start`. Calling `restore(last.state)` also reverts the provider to the previous step, discarding the latest match.
📍 Location: PreferenceRank.html, lines 1300-1304 (inside `restoreBattle(battle)`)
💥 Symptoms: Users are unable to resume any incomplete Quick Rank sessions from local storage; the app freezes or fails to display the battle screen.
💉 Treatment: Removed the legacy `_start` and `restore` conditionals and uniformly use `Object.assign(this.provider, battle.provider)` to directly hydrate the `QuickPairProvider` state from the saved payload, preserving the current step exactly.
🧪 Test: Simulated a saved battle session with `providerType === 'quick'` in a headless DOM environment and verified that `restoreBattle` properly rebuilds the provider state without throwing an error and successfully transitions to the battle screen.

---
*PR created automatically by Jules for task [2211815906254099967](https://jules.google.com/task/2211815906254099967) started by @mahalisyarifuddin*