### PR TITLE
🩺 Medic: Fix ignored tie handling in Bradley-Terry calculations

### DIFF
--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1410,6 +1410,17 @@
 						}
 					}
 
+					if (this.matches) {
+						for (const match of this.matches) {
+							if (match.result === 0.5) {
+								wins[match.a] += 0.5;
+								wins[match.b] += 0.5;
+								adjMaps[match.a].set(match.b, (adjMaps[match.a].get(match.b) || 0) + 1);
+								adjMaps[match.b].set(match.a, (adjMaps[match.b].get(match.a) || 0) + 1);
+							}
+						}
+					}
+
 					this.adj = adjMaps.map(m=>{
 						const row = new Int32Array(m.size * 2);
 						let k = 0;


### PR DESCRIPTION
In `PreferenceRank.html`, the `recalculateScores()` function relied entirely on `this.reach` (a transitive closure map) to determine the matches played and win counts. Because `this.reach` only registers strict wins/losses (result 1 or 0), explicit ties (`result === 0.5`) were completely ignored. 

This fix iterates over `this.matches` during the recalculation step to inject tied matches directly into the Bradley-Terry data structures (`wins` and `adjMaps`). It assigns `0.5` points to both competitors, ensuring accurate ranking when ties are allowed and selected.

---
*PR created automatically by Jules for task [6759415440198495347](https://jules.google.com/task/6759415440198495347) started by @mahalisyarifuddin*