### PR TITLE
Fix infinite loop in FullPairProvider on skipped pairs

### DIFF
--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1553,7 +1553,7 @@
 					this.clear();
 					const n = this.items.length;
 					let nextPair = this.provider.next(this, result);
-					while (nextPair && (this.reach[nextPair[0] * n + nextPair[1]] || this.reach[nextPair[1] * n + nextPair[0]])) {
+					while (this.provider instanceof QuickPairProvider && nextPair && (this.reach[nextPair[0] * n + nextPair[1]] || this.reach[nextPair[1] * n + nextPair[0]])) {
 						this.provider.isTransitiveDiscovery = true;
 						this.provider._lastTransitiveResult = this.reach[nextPair[0] * n + nextPair[1]] ? 1 : 0;
 						nextPair = this.provider.next(this, this.provider._lastTransitiveResult);

--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1034,17 +1034,20 @@
 						this.pairs[i] = this.pairs[j];
 						this.pairs[j] = temp;
 					}
+					this.index = 0;
 				}
-				next(state) {
-					return this.pairs[state.step];
+				next() {
+					return this.index < this.pairs.length ? this.pairs[this.index++] : null;
 				}
 				getProgress(step) {
 					return `${step}/${this.pairs.length}`;
 				}
 				snap() {
-					return null;
+					return this.index;
 				}
-				restore() {}
+				restore(state) {
+					state !== null && state !== undefined && (this.index = state);
+				}
 			}
 			class QuickPairProvider {
 				constructor(count) {


### PR DESCRIPTION
This PR fixes an infinite loop freeze that occurred when using the Full Rank mode (FullPairProvider) with any number of items (even small numbers like 4). The issue was caused by the transitive discovery loop attempting to fetch the next pair using the current step, which was not updated during the transitive skip process. Refactoring FullPairProvider to maintain its own pointer index and implementing proper state serialization resolves the bug completely while preserving Undo history and saving capabilities.

---
*PR created automatically by Jules for task [6293764074734396669](https://jules.google.com/task/6293764074734396669) started by @mahalisyarifuddin*