### PR TITLE
🩺 Medic: Fix Uint8Array hydration on session restore

### DIFF
--- a/.jules/codecraft.md
+++ b/.jules/codecraft.md
@@ -12,3 +12,8 @@
 **Mode:** Medic
 **Learning:** `QuickPairProvider` manages its execution via a serializable state stack and plain object properties, unlike previous sorting providers that relied on replaying history via `_start()` or `restore()`. Therefore, it can be directly hydrated from `localStorage` using `Object.assign`. Calling the non-existent `_start` or the improperly functioning `restore` causes the app to crash or lose state when resuming a session.
 **Action:** When restoring provider state for new algorithms in `restoreBattle`, rely on flat property assignment if the provider was designed to cleanly serialize its internal state to the `localStorage` payload, avoiding the invocation of specialized lifecycle methods that are no longer part of the provider's API.
+
+## 2024-05-24 - Typed Array Hydration on State Restore
+**Mode:** Medic
+**Learning:** When saving session state to `localStorage`, `Uint8Array` objects (like the `reach` matrix) are serialized by `JSON.stringify` into plain objects with numeric string keys (e.g., `{"0": 1, "1": 0}`). When loaded via `JSON.parse`, they remain plain objects. Simply assigning these parsed objects back to properties expected to be `Uint8Array`s will cause downstream type errors when methods relying on array behavior or `new Uint8Array(plainObject)` are called.
+**Action:** When restoring serialized state that contains Typed Arrays, explicitly reconstruct the objects using `new Uint8Array(Object.values(parsedObject))` to ensure subsequent operations that depend on Typed Array semantics function correctly.

--- a/PreferenceRank.html
+++ b/PreferenceRank.html
@@ -1295,6 +1295,8 @@
 				}
 				restoreBattle(battle) {
 					Object.assign(this, battle);
+					if (this.reach) this.reach = new Uint8Array(Object.values(this.reach));
+					if (this.history) this.history.forEach(h => { if (h.reach) h.reach = new Uint8Array(Object.values(h.reach)); });
 					this.dirty = true;
 					this.showGrade = !!battle.showGrade;
 					elements.showGrade.checked = this.showGrade;


### PR DESCRIPTION
- Addressed a bug where `Uint8Array` properties (`reach` and `history` `reach` items) were not properly reconstructed when parsed from JSON during `restoreBattle`.
- Used `Object.values()` to extract array elements and wrapped them in a `new Uint8Array()` constructor.
- This ensures transitive matrix arrays correctly maintain type-specific semantics after session resumption.

---
*PR created automatically by Jules for task [2294813125034447654](https://jules.google.com/task/2294813125034447654) started by @mahalisyarifuddin*